### PR TITLE
Refactor healthcheck

### DIFF
--- a/service/dummy_service.go
+++ b/service/dummy_service.go
@@ -3,16 +3,53 @@ package service
 import "net/http"
 
 func Dummy() {
-	http.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{
-  "BlockStorage.BlockHeight": {
-    "Name": "BlockStorage.BlockHeight",
-    "Value": 3715964
+  "Timestamp": "2020-06-30T15:48:18.434309+03:00",
+  "Status": "Last Successful Committed Block was too long ago",
+  "Error": "",
+  "Payload": {
+    "Uptime": 25,
+    "BlockStorage_BlockHeight": 501,
+    "StateStorage_BlockHeight": 501,
+    "BlockStorage_LastCommitted": 1574694046590916000,
+    "Gossip_IncomingConnections": 0,
+    "Gossip_OutgoingConnections": 0,
+    "Management_LastUpdated": 0,
+    "Management_Subscription": "Active",
+    "Version": {
+      "Semantic": "",
+      "Commit": ""
+    }
   }
 }`))
 	})
 
-	http.HandleFunc("/500", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/status.500", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{
+  "Timestamp": "2020-06-30T15:48:18.434309+03:00",
+  "Status": "Last Successful Committed Block was too long ago",
+  "Error": "",
+  "Payload": {
+    "Uptime": 25,
+    "BlockStorage_BlockHeight": 501,
+    "StateStorage_BlockHeight": 501,
+    "BlockStorage_LastCommitted": 1574694046590916000,
+    "Gossip_IncomingConnections": 0,
+    "Gossip_OutgoingConnections": 0,
+    "Management_LastUpdated": 0,
+    "Management_Subscription": "Active",
+    "Version": {
+      "Semantic": "",
+      "Commit": ""
+    }
+  }
+}
+`))
+	})
+
+	http.HandleFunc("/status.failed", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte{1, 2, 3})
 	})
 }


### PR DESCRIPTION
Only resort to returning default status in case something went terribly wrong (connection errors, json parsing errors).

Otherwise just relay the original JSON.